### PR TITLE
Add script arguments to define data location and computational resources available that influence dashboard behaviour and output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ EXPOSE 8501
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 ### In future might have dashboard on public git repo.
 ### Once streamlit has MVP going expose to user in popup website
-ENTRYPOINT ["streamlit", "run", "surveyweathertool/Home.py", "--server.port=8501", "--server.address=0.0.0.0"]
+ENTRYPOINT ["streamlit", "run", "surveyweathertool/Home.py", "--server.port=8501", "--server.address=0.0.0.0", "--", "--datalocation=gdrive", "--computation=low_resource"]
 
 # By running the Docker container, the pipeline gets triggered
 # ENTRYPOINT [ "bash" ]

--- a/surveyweathertool/pages/1_📈_LSMS-ISA_Dashboard.py
+++ b/surveyweathertool/pages/1_📈_LSMS-ISA_Dashboard.py
@@ -40,9 +40,6 @@ from src.dashboard.utils import parse_command_arguments
 # Parse the arguments passend when running the streamlit run command
 datalocation, computation = parse_command_arguments()
 
-print(f"datalocation: {datalocation} with type {type(datalocation)}")
-print(f"datalocation: {computation} with type {type(computation)}")
-
 # Page Configuration
 st.set_page_config(page_title="LSMS-ISA Dashboard", page_icon="📈")
 

--- a/surveyweathertool/pages/1_📈_LSMS-ISA_Dashboard.py
+++ b/surveyweathertool/pages/1_📈_LSMS-ISA_Dashboard.py
@@ -18,11 +18,12 @@ from src.weather.weather_pipeline import (
 from src.weather.utils import read_shape_file
 from src.weather.create_visuals import (
     generate_choropleth,
-    # generate_interactive_time_series,
+    generate_interactive_time_series,
     generate_bivariate_map,
     plot_poverty_index,
 )
-# from src.weather.weather_pipeline import plot_heatmap_grid_on_map
+
+from src.weather.weather_pipeline import plot_heatmap_grid_on_map
 from src.weather.constants import (
     TEMPERATURE_FILE,
     PRECIPITATION_FILE,
@@ -308,14 +309,6 @@ if submitted:
                 month=month_choice_dropdown,
                 season=season_choice,
             )
-            # time_series_1 = filter_weather(
-            #     weather_df=dict_value_cols[weather_dropdown[0]][0].copy(),
-            #     year=year_choice_dropdown,
-            # )
-            # time_series_2 = filter_weather(
-            #     weather_df=dict_value_cols[weather_dropdown[1]][0].copy(),
-            #     year=year_choice_dropdown,
-            # )
 
             if level == "month":
                 aggregated_prec_grid_1 = aggr_monthly(
@@ -379,43 +372,53 @@ if submitted:
             )
             folium_static(bivariate_map)
 
-            # st.plotly_chart(
-            #     generate_interactive_time_series(
-            #         df=time_series_1.copy(), weather_data_name=weather_columns[0]
-            #     )
-            # )
-            # st.plotly_chart(
-            #     generate_interactive_time_series(
-            #         df=time_series_2.copy(), weather_data_name=weather_columns[1]
-            #     )
-            # )
+            if computation == "high_resource":
+                time_series_1 = filter_weather(
+                    weather_df=dict_value_cols[weather_dropdown[0]][0].copy(),
+                    year=year_choice_dropdown,
+                )
+                time_series_2 = filter_weather(
+                    weather_df=dict_value_cols[weather_dropdown[1]][0].copy(),
+                    year=year_choice_dropdown,
+                )
 
-            # st.markdown(
-            #     f"<h4 style='text-align: center; color: black;'>Heatmap for {weather_dropdown[0]} </h4>",
-            #     unsafe_allow_html=True,
-            # )
-            # st.pyplot(
-            #     plot_heatmap_grid_on_map(
-            #         df=filtered_grid_1,
-            #         value_col="mean",
-            #         geo_df=nigeria_shape_df,
-            #         legend_title=legends[weather_dropdown[0]],
-            #         cmap=dict_value_cols[weather_dropdown[0]][1],
-            #     )
-            # )
-            # st.markdown(
-            #     f"<h4 style='text-align: center; color: black;'>Heatmap for {weather_dropdown[1]} </h4>",
-            #     unsafe_allow_html=True,
-            # )
-            # st.pyplot(
-            #     plot_heatmap_grid_on_map(
-            #         df=filtered_grid_2,
-            #         value_col="mean",
-            #         geo_df=nigeria_shape_df,
-            #         legend_title=legends[weather_dropdown[1]],
-            #         cmap=dict_value_cols[weather_dropdown[1]][1],
-            #     )
-            # )
+                st.plotly_chart(
+                    generate_interactive_time_series(
+                        df=time_series_1.copy(), weather_data_name=weather_columns[0]
+                    )
+                )
+                st.plotly_chart(
+                    generate_interactive_time_series(
+                        df=time_series_2.copy(), weather_data_name=weather_columns[1]
+                    )
+                )
+
+                st.markdown(
+                    f"<h4 style='text-align: center; color: black;'>Heatmap for {weather_dropdown[0]} </h4>",
+                    unsafe_allow_html=True,
+                )
+                st.pyplot(
+                    plot_heatmap_grid_on_map(
+                        df=filtered_grid_1,
+                        value_col="mean",
+                        geo_df=nigeria_shape_df,
+                        legend_title=legends[weather_dropdown[0]],
+                        cmap=dict_value_cols[weather_dropdown[0]][1],
+                    )
+                )
+                st.markdown(
+                    f"<h4 style='text-align: center; color: black;'>Heatmap for {weather_dropdown[1]} </h4>",
+                    unsafe_allow_html=True,
+                )
+                st.pyplot(
+                    plot_heatmap_grid_on_map(
+                        df=filtered_grid_2,
+                        value_col="mean",
+                        geo_df=nigeria_shape_df,
+                        legend_title=legends[weather_dropdown[1]],
+                        cmap=dict_value_cols[weather_dropdown[1]][1],
+                    )
+                )
 
             st.markdown(
                 f"<h4 style='text-align: center; color: black;'>Univariate map for {weather_dropdown[0]} </h4>",
@@ -504,30 +507,32 @@ if submitted:
             )
             folium_static(bivariate_map)
 
-            # st.plotly_chart(
-            #     generate_interactive_time_series(
-            #         df=filtered_df_2.copy(), weather_data_name="mean"
-            #     )
-            # )
-            # st.plotly_chart(
-            #     generate_interactive_time_series(
-            #         df=survey_data_df.copy(), weather_data_name=poverty_indicators[poverty_index_dropdown]
-            #     )
-            # )
+            if computation == "high_resource":
+                st.plotly_chart(
+                    generate_interactive_time_series(
+                        df=filtered_df_2.copy(), weather_data_name="mean"
+                    )
+                )
+                st.plotly_chart(
+                    generate_interactive_time_series(
+                        df=survey_data_df.copy(),
+                        weather_data_name=poverty_indicators[poverty_index_dropdown],
+                    )
+                )
 
-            # st.markdown(
-            #     f"<h4 style='text-align: center; color: black;'>Heatmap for {weather_dropdown[0]} </h4>",
-            #     unsafe_allow_html=True,
-            # )
-            # st.pyplot(
-            #     plot_heatmap_grid_on_map(
-            #         df=aggregated_prec_grid_1_year.copy(),
-            #         geo_df=nigeria_shape_df,
-            #         value_col="mean",
-            #         legend_title=legends[weather_dropdown[0]],
-            #         cmap=dict_value_cols[weather_dropdown[0]][1],
-            #     )
-            # )
+                st.markdown(
+                    f"<h4 style='text-align: center; color: black;'>Heatmap for {weather_dropdown[0]} </h4>",
+                    unsafe_allow_html=True,
+                )
+                st.pyplot(
+                    plot_heatmap_grid_on_map(
+                        df=aggregated_prec_grid_1_year.copy(),
+                        geo_df=nigeria_shape_df,
+                        value_col="mean",
+                        legend_title=legends[weather_dropdown[0]],
+                        cmap=dict_value_cols[weather_dropdown[0]][1],
+                    )
+                )
 
             st.markdown(
                 f"<h4 style='text-align: center; color: black;'>Univariate map for {poverty_index_dropdown} </h4>",
@@ -619,35 +624,36 @@ if submitted:
                 season=season_choice,
             )
 
-            # st.plotly_chart(
-            #     generate_interactive_time_series(
-            #         df=filtered_df_1.copy(), weather_data_name=weather_columns[0]
-            #     )
-            # )
+            if computation == "high_resource":
+                st.plotly_chart(
+                    generate_interactive_time_series(
+                        df=filtered_df_1.copy(), weather_data_name=weather_columns[0]
+                    )
+                )
 
-            # time_series_1 = filter_weather(
-            #     weather_df=dict_value_cols[weather_dropdown[0]][0].copy(),
-            #     year=year_choice_dropdown,
-            # )
-            # st.plotly_chart(
-            #     generate_interactive_time_series(
-            #         df=time_series_1.copy(), weather_data_name=weather_columns[0]
-            #     )
-            # )
+                time_series_1 = filter_weather(
+                    weather_df=dict_value_cols[weather_dropdown[0]][0].copy(),
+                    year=year_choice_dropdown,
+                )
+                st.plotly_chart(
+                    generate_interactive_time_series(
+                        df=time_series_1.copy(), weather_data_name=weather_columns[0]
+                    )
+                )
 
-            # st.markdown(
-            #     f"<h4 style='text-align: center; color: black;'>Heatmap for {weather_dropdown[0]} </h4>",
-            #     unsafe_allow_html=True,
-            # )
-            # st.pyplot(
-            #     plot_heatmap_grid_on_map(
-            #         df=filtered_grid_1,
-            #         geo_df=nigeria_shape_df,
-            #         value_col="mean",
-            #         legend_title=legends[weather_dropdown[0]],
-            #         cmap=dict_value_cols[weather_dropdown[0]][1],
-            #     )
-            # )
+                st.markdown(
+                    f"<h4 style='text-align: center; color: black;'>Heatmap for {weather_dropdown[0]} </h4>",
+                    unsafe_allow_html=True,
+                )
+                st.pyplot(
+                    plot_heatmap_grid_on_map(
+                        df=filtered_grid_1,
+                        geo_df=nigeria_shape_df,
+                        value_col="mean",
+                        legend_title=legends[weather_dropdown[0]],
+                        cmap=dict_value_cols[weather_dropdown[0]][1],
+                    )
+                )
 
             st.markdown(
                 f"<h4 style='text-align: center; color: black;'>Univariate map for {weather_dropdown[0]} </h4>",
@@ -699,11 +705,13 @@ if submitted:
                     fill_color="Reds",
                 )
             )
-            # st.plotly_chart(
-            #     generate_interactive_time_series(
-            #         df=survey_data_df.copy(), weather_data_name=weather_columns[0]
-            #     )
-            # )
+
+            if computation == "high_resource":
+                st.plotly_chart(
+                    generate_interactive_time_series(
+                        df=survey_data_df.copy(), weather_data_name=weather_columns[0]
+                    )
+                )
 
             st.markdown(
                 f"<h4 style='text-align: center; color: black;'>Households on map for {poverty_index_dropdown} </h4>",

--- a/surveyweathertool/pages/1_📈_LSMS-ISA_Dashboard.py
+++ b/surveyweathertool/pages/1_📈_LSMS-ISA_Dashboard.py
@@ -39,6 +39,10 @@ from src.dashboard.utils import parse_command_arguments
 
 # Parse the arguments passend when running the streamlit run command
 datalocation, computation = parse_command_arguments()
+
+print(f"datalocation: {datalocation} with type {type(datalocation)}")
+print(f"datalocation: {computation} with type {type(computation)}")
+
 # Page Configuration
 st.set_page_config(page_title="LSMS-ISA Dashboard", page_icon="📈")
 

--- a/surveyweathertool/src/dashboard/utils.py
+++ b/surveyweathertool/src/dashboard/utils.py
@@ -236,7 +236,16 @@ def parse_command_arguments() -> tuple:
     parser.add_argument("-c", "--computation", type=str)
 
     args = parser.parse_args()
-    datalocation = args.datalocation
+
     computation = args.computation
+
+    if args.datalocation is None:
+        datalocation = "gdrive"
+    else:
+        datalocation = args.datalocation
+    if args.computation is None:
+        computation = "low_resource"
+    else:
+        computation = args.computation
 
     return (datalocation, computation)

--- a/surveyweathertool/src/dashboard/utils.py
+++ b/surveyweathertool/src/dashboard/utils.py
@@ -7,6 +7,8 @@ import streamlit as st
 from PIL import Image
 from pathlib import Path
 from typing import List, Optional
+import argparse
+
 
 from src.weather.weather_pipeline import convert_point_crs
 
@@ -226,3 +228,15 @@ def dataframe_reader(
     if reset_index:
         data = data.reset_index()
     return data
+
+
+def parse_command_arguments() -> tuple:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--datalocation", type=str)
+    parser.add_argument("-c", "--computation", type=str)
+
+    args = parser.parse_args()
+    datalocation = args.datalocation
+    computation = args.computation
+
+    return (datalocation, computation)


### PR DESCRIPTION
This PR makes it possible to add script arguments or define default arguments when running the Streamlit dashboard. In specific, to define where the data needed for the dashboard is being stored (current options: "gdrive" and "local) and if computational resources are provided (current options: "low_resources" - normal local resources of a standard pc/laptop, "high_resources" - e.g. during the project a VM with the following specs has been used: 16 CPUs, RAM 24 GB, 1 TB disk). This makes it possible to run the code locally with either loading the data from Google Drive or from another locally accessible storage. Some visualisations are currently not being run, as they require the more fine-grained data, that in turn requires computational resources higher than what currently provides the free hosting solution Streamlit Cloud.

 Here an overview over the specific adjustments made in each file.

`surveyweathertool/src/dashboard/utils.py`: Adds a new dashboard util function to be able to process added script arguments when running the dashboard. If none are provided, it defines also the default values here.

`Dockerfile`: Updates the docker run command with adding arguments for data location and computational resources.

`surveyweathertool/pages/1_📈_LSMS-ISA_Dashboard.py`: Restructures the code and according to which data location and computational resources specified, defines which data sets to use for the dashboard and which visualisations to show (previously commented out visualisations requiring more fine-grained data requiring more computational power were brought back)

`surveyweathertool/pages/2_📊_Weather_Data_Enhancement.py`: Restructures the code and according to which data location and computational resources specified, defines which data sets to use for the dashboard.